### PR TITLE
rename handler to app.landsat.APP

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -38,7 +38,7 @@ package:
 
 functions:
   landsat-tiler:
-    handler: app.landsat.LANDSAT_APP
+    handler: app.landsat.APP
     memorySize: 1536
     timeout: 20
     events:


### PR DESCRIPTION
The method used to be called LANDSAT_APP but is now called APP.